### PR TITLE
Add direct arguments for login and download

### DIFF
--- a/AoDDownloader/AoDDownloader.py
+++ b/AoDDownloader/AoDDownloader.py
@@ -202,16 +202,16 @@ class AoDDownloader(object):
             self.current_playlist = [self._parse_episode(
                 episodeData) for episodeData in pd]
 
-    def download(self, verbose: bool, noBuffer: bool):
+    def download(self, verbose: bool, noBufferOutput: bool):
         for episode in self.playlist:
             if episode.exists:
                 click.echo(f"{click.style(f'Skipping {episode.title}.', fg='green')} Already exists.")
                 continue
             with tempfile.NamedTemporaryFile() if os.name != 'nt' else open(episode.file + ".ts", "w+b") as tmp:
                 with click.progressbar(episode.chunkList, label=f"Downloading {episode.title}:") as chunkList:
-                    for chunkUrl in chunkList:
-                        if noBuffer:
-                            click.echo("")
+                    for index, chunkUrl in enumerate(chunkList):
+                        if noBufferOutput:
+                            click.echo("\n" + str(index) + "/" + str(chunkList.length))
                         chunk_response = self.session.get(chunkUrl)
                         if chunk_response.status_code != 200:
                             if chunk_response.status_code == 403:

--- a/AoDDownloader/AoDDownloader.py
+++ b/AoDDownloader/AoDDownloader.py
@@ -202,7 +202,7 @@ class AoDDownloader(object):
             self.current_playlist = [self._parse_episode(
                 episodeData) for episodeData in pd]
 
-    def download(self, verbose: bool):
+    def download(self, verbose: bool, noBuffer: bool):
         for episode in self.playlist:
             if episode.exists:
                 click.echo(f"{click.style(f'Skipping {episode.title}.', fg='green')} Already exists.")
@@ -210,6 +210,8 @@ class AoDDownloader(object):
             with tempfile.NamedTemporaryFile() if os.name != 'nt' else open(episode.file + ".ts", "w+b") as tmp:
                 with click.progressbar(episode.chunkList, label=f"Downloading {episode.title}:") as chunkList:
                     for chunkUrl in chunkList:
+                        if noBuffer:
+                            click.echo("")
                         chunk_response = self.session.get(chunkUrl)
                         if chunk_response.status_code != 200:
                             if chunk_response.status_code == 403:

--- a/AoDDownloader/cli.py
+++ b/AoDDownloader/cli.py
@@ -23,13 +23,17 @@ def cli():
               help='Try downloading japanese audio with german subtitles.')
 @click.option('-g', '--german', 'german', is_flag=True,
               help='Try downloading german audio.')
-def download(german, japanese, quality, verbose):
+@click.argument('url', default='')
+def download(german, japanese, quality, verbose, url):
     """
     Download an anime.
     The files are downloaded in the current directory.
     """
     downloader = create_downloader()
-    anime_url = click.prompt('Enter anime url or id to download')
+    if url:
+        anime_url= url
+    else:
+        anime_url = click.prompt('Enter anime url or id to download')
     if quality:
         if verbose:
             click.echo(f"Override quality settings")
@@ -49,11 +53,16 @@ def download(german, japanese, quality, verbose):
 @cli.command()
 @click.option('--no-keyring', 'no_keyring', is_flag=True,
               help='Deactivate keyring option for systems who have no accessible keyring')
-def login(no_keyring):
+@click.argument('name', default='')
+@click.argument('password', default='')
+def login(no_keyring, name, password):
     """
     Login to anime-on-demand.de and save credentials
     """
-    create_login(use_keyring=not no_keyring)
+    if name and password:
+        create_login(not no_keyring, name, password)
+    else:
+        create_login(not no_keyring)
 
 
 @cli.command()

--- a/AoDDownloader/cli.py
+++ b/AoDDownloader/cli.py
@@ -24,12 +24,16 @@ def cli():
 @click.option('-g', '--german', 'german', is_flag=True,
               help='Try downloading german audio.')
 @click.argument('url', default='')
-def download(german, japanese, quality, verbose, url):
+@click.argument('password', default='')
+def download(german, japanese, quality, verbose, url, password):
     """
     Download an anime.
     The files are downloaded in the current directory.
     """
-    downloader = create_downloader()
+    if password:
+        downloader = create_downloader(password)
+    else:
+        downloader = create_downloader()
     if url:
         anime_url= url
     else:

--- a/AoDDownloader/cli.py
+++ b/AoDDownloader/cli.py
@@ -23,9 +23,11 @@ def cli():
               help='Try downloading japanese audio with german subtitles.')
 @click.option('-g', '--german', 'german', is_flag=True,
               help='Try downloading german audio.')
+@click.option('--no-buffer', 'noBuffer', is_flag=True,
+              help='Disable buffering for progress output.')
 @click.argument('url', default='')
 @click.argument('password', default='')
-def download(german, japanese, quality, verbose, url, password):
+def download(german, japanese, quality, verbose, url, password, noBuffer):
     """
     Download an anime.
     The files are downloaded in the current directory.
@@ -49,7 +51,7 @@ def download(german, japanese, quality, verbose, url, password):
         downloader.config.german = german
     try:
         downloader.set_playlist(anime_url, verbose)
-        downloader.download(verbose)
+        downloader.download(verbose, noBuffer)
     except _AoDDownloader.AoDDownloaderException as e:
         click.echo(f"{click.style('Error:', fg='red')} {e}")
 

--- a/AoDDownloader/cli.py
+++ b/AoDDownloader/cli.py
@@ -23,11 +23,11 @@ def cli():
               help='Try downloading japanese audio with german subtitles.')
 @click.option('-g', '--german', 'german', is_flag=True,
               help='Try downloading german audio.')
-@click.option('--no-buffer', 'noBuffer', is_flag=True,
+@click.option('--no-buffer-output', 'noBufferOutput', is_flag=True,
               help='Disable buffering for progress output.')
 @click.argument('url', default='')
 @click.argument('password', default='')
-def download(german, japanese, quality, verbose, url, password, noBuffer):
+def download(german, japanese, quality, verbose, url, password, noBufferOutput):
     """
     Download an anime.
     The files are downloaded in the current directory.
@@ -51,7 +51,7 @@ def download(german, japanese, quality, verbose, url, password, noBuffer):
         downloader.config.german = german
     try:
         downloader.set_playlist(anime_url, verbose)
-        downloader.download(verbose, noBuffer)
+        downloader.download(verbose, noBufferOutput)
     except _AoDDownloader.AoDDownloaderException as e:
         click.echo(f"{click.style('Error:', fg='red')} {e}")
 

--- a/AoDDownloader/utils.py
+++ b/AoDDownloader/utils.py
@@ -42,13 +42,13 @@ def create_login(use_keyring: bool = True, username: str = '', password: str = '
     if use_keyring:
         try:
             keyring.set_password(config.APPKEY, username=config.username, password=config.password)
-            click.echo("Login erfolgreich.")
         except NoKeyringError:
             click.echo(
                 f"""{click.style('Keyring is not accessible.', fg='red')}
 "pip install dbus-python" might fix this problem.
 Or use --no-keyring to enter password every time and disable keyring""")
     config.write()
+    click.echo("Login erfolgreich.")
 
 
 def remove_login():

--- a/AoDDownloader/utils.py
+++ b/AoDDownloader/utils.py
@@ -6,7 +6,7 @@ import AoDDownloader as AoD
 from .config import Config
 
 
-def create_downloader() -> AoD.AoDDownloader:
+def create_downloader(password) -> AoD.AoDDownloader:
     config = Config()
 
     if config.username:
@@ -17,7 +17,10 @@ def create_downloader() -> AoD.AoDDownloader:
                 click.echo(
                     "Keyring is not accessible.\n \"pip install dbus-python\" might fix this problem.")
         else:
-            config.password = click.prompt('Password', hide_input=True)
+            if password:
+                config.password = password
+            else:
+                config.password = click.prompt('Password', hide_input=True)
     return AoD.AoDDownloader(config=config)
 
 

--- a/AoDDownloader/utils.py
+++ b/AoDDownloader/utils.py
@@ -21,10 +21,14 @@ def create_downloader() -> AoD.AoDDownloader:
     return AoD.AoDDownloader(config=config)
 
 
-def create_login(use_keyring: bool = True):
+def create_login(use_keyring: bool = True, username: str = '', password: str = ''):
     config = Config()
-    config.username = click.prompt('Username')
-    config.password = click.prompt('Password', hide_input=True)
+    if(not username or not password):
+        config.username = click.prompt('Username')
+        config.password = click.prompt('Password', hide_input=True)
+    else:
+        config.username = username
+        config.password = password
     config.keyring = use_keyring
     try:
         aod = AoD.AoDDownloader(config=config)
@@ -38,6 +42,7 @@ def create_login(use_keyring: bool = True):
     if use_keyring:
         try:
             keyring.set_password(config.APPKEY, username=config.username, password=config.password)
+            click.echo("Login erfolgreich.")
         except NoKeyringError:
             click.echo(
                 f"""{click.style('Keyring is not accessible.', fg='red')}

--- a/AoDDownloader/utils.py
+++ b/AoDDownloader/utils.py
@@ -17,10 +17,7 @@ def create_downloader(password) -> AoD.AoDDownloader:
                 click.echo(
                     "Keyring is not accessible.\n \"pip install dbus-python\" might fix this problem.")
         else:
-            if password:
-                config.password = password
-            else:
-                config.password = click.prompt('Password', hide_input=True)
+            config.password = password if password else click.prompt('Password', hide_input=True)
     return AoD.AoDDownloader(config=config)
 
 
@@ -39,7 +36,7 @@ def create_login(use_keyring: bool = True, username: str = '', password: str = '
         click.echo(e)
         return
     if not aod.signed_in:
-        click.echo("Login fehlgeschlagen.")
+        click.echo("Login failed.")
         return
 
     if use_keyring:
@@ -51,7 +48,7 @@ def create_login(use_keyring: bool = True, username: str = '', password: str = '
 "pip install dbus-python" might fix this problem.
 Or use --no-keyring to enter password every time and disable keyring""")
     config.write()
-    click.echo("Login erfolgreich.")
+    click.echo("Login successfull.")
 
 
 def remove_login():

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - add integer only support
 - add escape of ffmpeg strings
 - add progressbar when parsing episodes
+- add direct arguments for login and download
 - try signing in when 403 is thrown
 
 # 1.0.0rc5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add escape of ffmpeg strings
 - add progressbar when parsing episodes
 - add direct arguments for login and download
+- add `no-buffer-output ` option to get a not buffered output
 - try signing in when 403 is thrown
 
 # 1.0.0rc5


### PR DESCRIPTION
This commit will close issue #21
Now commands like
`AoDDownloader download https://www.anime-on-...` ,
`AoDDownloader download 423`  and
`AoDDownloader login [username] [password]` are possible.

Also added a login success message (Why are these in German?)